### PR TITLE
Automatically refresh upon new snapshot data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'acts_as_list' # order Project#stages
 gem 'releasecop', '>= 0.0.13' # compare release stages
 gem 'activeadmin' # manage models
+gem 'redis' # actioncable adapter
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redis (4.0.3)
     releasecop (0.0.13)
       thor
     responders (2.4.0)
@@ -252,6 +253,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
   rails (~> 5.2.1)
+  redis
   releasecop (>= 0.0.13)
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/channels/project.coffee.erb
+++ b/app/assets/javascripts/channels/project.coffee.erb
@@ -1,0 +1,15 @@
+$(->
+  App.project = App.cable.subscriptions.create {
+    channel: "ProjectChannel",
+    organization_id: $('#organization_subscription_identifier').val()
+  },
+    # connected: ->
+      # Called when the subscription is ready for use on the server
+
+    # disconnected: ->
+      # Called when the subscription has been terminated by the server
+
+    received: (data) ->
+      # Called when there's incoming data on the websocket for this channel
+      location.reload() if data.newSnapshots?
+)

--- a/app/channels/project_channel.rb
+++ b/app/channels/project_channel.rb
@@ -1,0 +1,17 @@
+class ProjectChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from self.class.channel_name(params[:organization_id])
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+
+  def self.channel_name(organization_id = nil)
+    "organization:#{organization_identifier(organization_id)}"
+  end
+
+  def self.organization_identifier(organization_id = nil)
+    (organization_id || -1).to_s # -1 indicates subscription to all organizations' updates
+  end
+end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,1 +1,2 @@
+<%= hidden_field_tag 'organization_subscription_identifier', ProjectChannel.organization_identifier(params[:organization_id]) %>
 <%= render partial: "index_#{@view}" %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,7 @@
 development:
-  adapter: async
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: horizon_development
 
 test:
   adapter: async

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -5,8 +5,10 @@ services:
     env_file: ../.env
     depends_on:
     - horizon-postgres
+    - horizon-redis
     environment:
     - DATABASE_URL=postgresql://postgres:@horizon-postgres/horizon_development
+    - REDIS_URL=redis://horizon-redis
     extends:
       file: build.yml
       service: horizon
@@ -18,3 +20,5 @@ services:
     image: postgres:9.5
     environment:
     - POSTGRES_DB=horizon_development
+  horizon-redis:
+    image: redis:3.2-alpine


### PR DESCRIPTION
I keep a tab open with the list of projects, and apparently a view is up on the wall screens as well, but until now they wouldn't refresh to reflect changes. This uses `actioncable` to broadcast a notification whenever there are changes to project comparisons. The index view(s) reload themselves based on this notification.

A cron is responsible for refreshing project comparisons currently. I refactored it slightly to iterate through projects on a per-organization basis and broadcast a notification after processing each organization, and optionally again after all organizations (for any viewers who are not filtering by `organization_id`).

This is my first use of `actioncable` so I wasn't sure how best to share server data with the client code and settled on just putting the filter params into a hidden field for the client-side code to pick up.

This works locally but will probably need some special configuration in kubernetes to support websockets. Will look at that next.